### PR TITLE
Fix gtk UI compile errors

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gtk4 = { version = "0.9", package = "gtk4" }
+gtk4 = { version = "0.9", package = "gtk4", features = ["v4_10"] }
 glib = "0.18"
 gtk4-layer-shell = "0.5"
-gdk4 = "0.9"
+gdk4 = { version = "0.9", features = ["v4_10"] }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -145,9 +145,9 @@ fn build_ui(app: &Application) {
     rgb_section.append(&sliders);
 
     advanced_switch.connect_state_set(
-        clone!(@weak sliders => @default-return glib::signal::Inhibit(false), move |_, state| {
+        clone!(@weak sliders => @default-return glib::Propagation::Proceed, move |_, state| {
             sliders.set_visible(state);
-            glib::signal::Inhibit(false)
+            glib::Propagation::Proceed
         }),
     );
 
@@ -165,7 +165,7 @@ fn build_ui(app: &Application) {
         .add_provider(&css_provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
     let update_preview = move |color: gdk4::RGBA| {
         let css = format!("background-color:{};", color.to_string());
-        css_provider.load_from_data(css.as_bytes()).ok();
+        css_provider.load_from_data(&css);
     };
     update_preview(color_button.rgba());
     color_button.connect_rgba_notify(clone!(@strong update_preview => move |btn| {
@@ -173,7 +173,7 @@ fn build_ui(app: &Application) {
     }));
     for scale in [&red, &green, &blue] {
         scale.connect_value_changed(
-            clone!(@weak color_button => @strong update_preview => move |_| {
+            clone!(@weak color_button, @strong update_preview => move |_| {
                 let mut color = color_button.rgba();
                 color.red = red.value() as f32 / 255.0;
                 color.green = green.value() as f32 / 255.0;


### PR DESCRIPTION
## Summary
- enable GTK 4.10 API to use ColorDialog
- update preview CSS handling
- switch to Propagation API for signal handlers
- fix clone! usage for scale callbacks

## Testing
- `cargo build` *(fails: The system library `gtk4-layer-shell-0` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b601861dc83279c2777018f95be8f