### PR TITLE
Add resolution switching and refresh rate buttons

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,5 +1,4 @@
 use gtk::gdk;
-use gtk::glib;
 use gtk::prelude::*;
 use gtk::{Align, Application, ApplicationWindow, Orientation};
 use gtk4 as gtk;
@@ -406,7 +405,8 @@ fn build_ui(app: &Application) {
             format!("{} ({})", m, ratio)
         })
         .collect();
-    let res_combo = gtk::DropDown::from_strings(&display_modes);
+    let display_refs: Vec<&str> = display_modes.iter().map(|s| s.as_str()).collect();
+    let res_combo = gtk::DropDown::from_strings(&display_refs);
     res_combo.set_selected(cur_idx as u32);
     row4.append(&gtk::Label::new(Some("Resolution:")));
     row4.append(&res_combo);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -102,10 +102,11 @@ fn rfkill_blocked(kind: &str) -> Option<bool> {
 
 fn is_wayland() -> bool {
     if let Some(display) = gdk::Display::default() {
-        if display.is_wayland() {
+        let backend = display.backend();
+        if backend.is_wayland() {
             return true;
         }
-        if display.is_x11() {
+        if backend.is_x11() {
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- populate resolution dropdown using `xrandr`
- compute aspect ratios and display them
- change display mode on selection
- adjust refresh rate buttons to call `xrandr` with the currently selected mode

## Testing
- `cargo check` *(fails: `gtk4-layer-shell-0.pc` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688bad29f1f48327a250fced6750dc89