### PR TITLE
Add RGB lighting configuration with modes and manual sliders

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -732,7 +732,7 @@ fn build_ui(app: &Application) {
                 }
             });
         }
-        hue_area.add_controller(&drag);
+        hue_area.add_controller(drag);
     }
 
     // Draw preview circle

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,5 +1,4 @@
 use gtk::gdk;
-use gtk::glib;
 use gtk::prelude::*;
 use gtk::{Align, Application, ApplicationWindow, Orientation};
 use gtk4 as gtk;
@@ -204,10 +203,10 @@ fn write_to_sysfs(path: &str, value: impl AsRef<str>) {
     }
 }
 
-const RGB_BASE: &str = "/sys/class/leds/multicolor:chassis";
+const RGB_BASE: &str = "/sys/class/leds/ayn:rgb:joystick_rings";
 
 fn rgb_set_mode(mode: u8) {
-    write_to_sysfs(&format!("{}/device/led_mode", RGB_BASE), mode.to_string());
+    write_to_sysfs(&format!("{}/led_mode", RGB_BASE), mode.to_string());
 }
 
 fn rgb_set_brightness(val: u8) {
@@ -219,10 +218,6 @@ fn rgb_set_intensity(r: u8, g: u8, b: u8) {
         &format!("{}/multi_intensity", RGB_BASE),
         format!("{} {} {}", r, g, b),
     );
-}
-
-fn rgb_set_index() {
-    write_to_sysfs(&format!("{}/multi_index", RGB_BASE), "red green blue");
 }
 
 fn pwm_base() -> Option<&'static str> {
@@ -592,7 +587,6 @@ fn build_ui(app: &Application) {
     vbox.append(&gtk::Separator::new(Orientation::Horizontal));
 
     // RGB Lighting section
-    rgb_set_index();
     let rgb_section = gtk::Box::new(Orientation::Vertical, 8);
     let rgb_label = gtk::Label::new(Some("RGB Lighting"));
     rgb_label.add_css_class("heading");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -617,8 +617,15 @@ fn build_ui(app: &Application) {
     // Mode selection
     let mode_row = gtk::Box::new(Orientation::Horizontal, 8);
     mode_row.append(&gtk::Label::new(Some("Mode:")));
-    let modes = gtk::DropDown::from_strings(&["Off", "Breathe", "Manual"]);
-    mode_row.append(&modes);
+    let off_btn = gtk::CheckButton::with_label("Off");
+    off_btn.set_active(true);
+    let breathe_btn = gtk::CheckButton::with_label("Breathe");
+    breathe_btn.set_group(Some(&off_btn));
+    let manual_btn = gtk::CheckButton::with_label("Manual");
+    manual_btn.set_group(Some(&off_btn));
+    mode_row.append(&off_btn);
+    mode_row.append(&breathe_btn);
+    mode_row.append(&manual_btn);
     rgb_section.append(&mode_row);
 
     // Manual controls
@@ -755,24 +762,33 @@ fn build_ui(app: &Application) {
     // Mode handler
     {
         let manual_box = manual_box.clone();
-        let apply = apply_settings.clone();
-        modes.connect_selected_notify(move |dd| match dd.selected() {
-            0 => {
+        off_btn.connect_toggled(move |btn| {
+            if btn.is_active() {
                 manual_box.set_visible(false);
                 rgb_set_mode(1);
                 rgb_set_brightness(0);
                 rgb_set_intensity(0, 0, 0);
             }
-            1 => {
+        });
+    }
+    {
+        let manual_box = manual_box.clone();
+        breathe_btn.connect_toggled(move |btn| {
+            if btn.is_active() {
                 manual_box.set_visible(false);
                 rgb_set_mode(0);
             }
-            2 => {
+        });
+    }
+    {
+        let manual_box = manual_box.clone();
+        let apply = apply_settings.clone();
+        manual_btn.connect_toggled(move |btn| {
+            if btn.is_active() {
                 manual_box.set_visible(true);
                 rgb_set_mode(1);
                 apply();
             }
-            _ => {}
         });
     }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -681,6 +681,7 @@ fn build_ui(app: &Application) {
         let hue = hue.clone();
         let apply = apply_settings.clone();
         let hue_area = hue_area.clone();
+        let draw_hue = hue.clone();
         hue_area.set_draw_func(move |_w, cr, width, height| {
             let grad = cairo::LinearGradient::new(0.0, 0.0, width as f64, 0.0);
             let stops = [
@@ -699,7 +700,7 @@ fn build_ui(app: &Application) {
             cr.rectangle(0.0, 0.0, width as f64, height as f64);
             let _ = cr.fill();
 
-            let x = hue.get() / 360.0 * width as f64;
+            let x = draw_hue.get() / 360.0 * width as f64;
             cr.set_source_rgb(1.0, 1.0, 1.0);
             cr.rectangle(x - 2.0, 0.0, 4.0, height as f64);
             let _ = cr.fill();


### PR DESCRIPTION
## Summary
- add sysfs helpers for RGB LED mode, brightness, and intensity
- expose RGB Lighting section with Off, Breathe, and Manual modes
- manual mode provides brightness and per-channel RGB sliders

## Testing
- `cargo build` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d0c305180832787cd7a69f8f09dca