### PR TITLE
Remove vibration toggle and placeholder label

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -802,13 +802,6 @@ fn build_ui(app: &Application) {
     vbox.append(&rgb_section);
     vbox.append(&gtk::Separator::new(Orientation::Horizontal));
 
-    // Row 10: Vibration toggle
-    let row10 = gtk::Box::new(Orientation::Horizontal, 8);
-    let vibration = gtk::CheckButton::with_label("Vibration");
-    row10.append(&vibration);
-    row10.append(&gtk::Label::new(Some("Stick calibration coming soon")));
-    vbox.append(&row10);
-
     scrolled.set_child(Some(&vbox));
     window.set_child(Some(&scrolled));
     window.present();


### PR DESCRIPTION
## Summary
- drop the unused vibration toggle from the UI
- remove the temporary "Stick calibration coming soon" message

## Testing
- `cargo fmt`
- `cargo check` *(fails: The system library `gtk4-layer-shell-0` required by crate `gtk4-layer-shell-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da4bedd9883278138895a5efe0273